### PR TITLE
Define typesController#index, #show

### DIFF
--- a/controllers/types.js
+++ b/controllers/types.js
@@ -1,11 +1,41 @@
-const api = 'https://pokeapi.co/api/v2/';
+const api = 'https://pokeapi.co/api/v2/type';
+const axios = require('axios');
 
 const index = (req, res) => {
-    res.json('this will render a list of types!');
+    axios
+    .get(api + '?limit=50&offset=0')
+    .then((response) => {
+        res.json({
+            types: response.data.results
+        });
+    })
+    .catch( (err) => {
+        console.log(err);
+        res.json ({
+            status: 404,
+            message: 'Internal Server Error'
+        });
+    });
 }
 
-const show = (req, res) => {
-    res.json('this will render a specific type!');
+const show = async (req, res) => {
+    const id = req.params.id;
+    console.log(id, ' <-- req.params.id');
+
+    try {
+        const foundType = await axios.get(`${api}/${id}`);
+        console.log(foundType.data.names[6], '<-- english information')
+        res.json({
+            type: foundType.data,
+            name: foundType.data.names[6].name
+        });
+    } catch (err) {
+        console.log(err);
+        res.json ({
+            status: 404,
+            message: 'Internal Server Error'
+        });
+    }
 }
 
 module.exports = {


### PR DESCRIPTION
Index is in promises (declarative syntax). As usual, we can grab JSON data from the pokeAPI as response.data.results, which would be accessed as "types" variable in types/index.ejs.

Show is in async/await. The foundType is all the JSON data being grabbed by req.params.id. Access all JSON data from the foundType by using "type" in the types/show.ejs. I put down "name" as a variable assignment to the name of the type for easy access in types/show.ejs.