### PR TITLE
Fix incorrect href in a element on pokemons/index.ejs

### DIFF
--- a/views/pokemons/index.ejs
+++ b/views/pokemons/index.ejs
@@ -5,7 +5,7 @@
         <div class="index-title"><h2>Pokemons</h2></div>
         <div class="flex-container">
             <% names.forEach(n => { %>
-                <div><a href="/pokemons/<%= n.name %>" class = "index-items"> <%= n.name %></a></div>
+                <div><a href="/pokemon/<%= n.name %>" class = "index-items"> <%= n.name %></a></div>
             <% }) %>
             
         </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/25293700/90583794-f07f5c80-e185-11ea-95c8-1e0087c4839f.png)

The index page was linking to '/pokemons/name' instead of '/pokemon/name'. This has been corrected in ```views/pokemons/index.ejs```